### PR TITLE
Fixing correct link for samsymons.com github

### DIFF
--- a/source/layout.erb
+++ b/source/layout.erb
@@ -45,7 +45,7 @@
         <%= yield %>
 
         <footer>
-          <p id="footer-details">&copy; 2013 Sam Symons. Available on <a href="http://github.com/samsymons/samsymons.github.com/">GitHub</a>. Subscribe to the <a href="/feed.xml">RSS feed</a> to stay updated.</p>
+          <p id="footer-details">&copy; 2013 Sam Symons. Available on <a href="http://github.com/samsymons/samsymons.com/">GitHub</a>. Subscribe to the <a href="/feed.xml">RSS feed</a> to stay updated.</p>
         </footer>
       </div>
     </div>


### PR DESCRIPTION
Just having a quick look at your blog when I noticed that the link in the footer was pointing to:
http://github.com/samsymons/samsymons.github.com/

Which doesn't exist.

The actual link was:
http://github.com/samsymons/samsymons.com/
